### PR TITLE
Prohibit the editing of username

### DIFF
--- a/src/tests/mock_users.py
+++ b/src/tests/mock_users.py
@@ -45,3 +45,10 @@ correct_user_update = {
     'full_name': 'Gixu Duribo',
     'password': 'vusmouke13'
 }
+
+wrong_user_update = {
+    'username': 'Vonosthur#',
+    'email': 'duriboelel@gmail.com',
+    'full_name': 'Gixu Duribo',
+    'password': 'vusmouke13'
+}

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -4,7 +4,8 @@ from controllers import user as controller
 from tests.mock_users import (
     correct_users,
     wrong_users,
-    correct_user_update
+    correct_user_update,
+    wrong_user_update
 )
 from database import db
 from database.models import User
@@ -88,6 +89,14 @@ class TestUser(unittest.TestCase):
         self.assertEqual(status, 200)
         correct_user_update['username'] = user['username']
         self.assertEqual(result, correct_user_update)
+
+        result, status = controller.update_user(
+            user['username'],
+            wrong_user_update
+        )
+
+        self.assertEqual(status, 400)
+        self.assertEqual(result,  "Username não pode ser atualizado.")
 
         for w_user in wrong_users:
             result, status = controller.update_user(

--- a/src/utils/validators/user.py
+++ b/src/utils/validators/user.py
@@ -43,6 +43,9 @@ def validate_update_user(body, params):
     for param in params:
         fields.append((param, str))
 
+    if 'username' in body:
+        return 'Username não pode ser atualizado.'
+
     wrong_fields = validate_fields_types(body, fields)
     if wrong_fields:
         wrong_fields = ", ".join(wrong_fields)
@@ -56,11 +59,6 @@ def validate_update_user(body, params):
     if 'email' in body:
         if not validate_email(body['email']):
             return "Email inválido"
-
-    if 'username' in body:
-        username_is_invalid = validate_username(body['username'])
-        if username_is_invalid:
-            return username_is_invalid
 
     if 'password' in body:
         if body['password'].isalpha():


### PR DESCRIPTION
## Issue 
Resolves #15 

## Description
Prohibit the editing of username

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## How to validate?
Try to edit a user's username and check the impediment.
Run the tests:
```$ docker-compose run api pytest```
