### PR TITLE
Adds right validation for occurrence_date_time

### DIFF
--- a/src/utils/validators/occurrence.py
+++ b/src/utils/validators/occurrence.py
@@ -6,7 +6,8 @@ def validate_create_occurrence(body):
     fields = [
         ('physical_aggression', bool), ('victim', bool),
         ('police_report', bool), ('gun', str),
-        ('location', list), ('occurrence_type', str)
+        ('location', list), ('occurrence_type', str),
+        ('occurrence_date_time', str)
     ]
 
     required_fields = [f[0] for f in fields]
@@ -22,8 +23,7 @@ def validate_create_occurrence(body):
         return f'Campos com tipo inválido: {wrong_fields}'
 
     if not validate_occurrence_date_time(body['occurrence_date_time']):
-        # return validate_occurrence_date_time(body['occurrence_date_time']
-        return "Data de Ocorrẽncia inválida."
+        return "Data de Ocorrência inválida."
 
     if not validate_gun(body['gun']):
         return "Arma inválida."


### PR DESCRIPTION
Adds the validation for occurrence_date_time attribute. If it is not in json, it will return the message "Os seguintes campos estão faltando: occurrence_date_time" with the code status 400.

## Issue #
#13 

## Description
It was edited the occurrence validator, adding the occurrence_date_time attribute as a required attribute.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
