### PR TITLE
Encrypt updated password

### DIFF
--- a/src/controllers/user.py
+++ b/src/controllers/user.py
@@ -2,6 +2,7 @@ from database.models import User
 from database import db
 from utils.formatters import get_row_dict
 from utils.validators.user import validate_create_user, validate_update_user
+from settings import BCRYPT
 
 
 def create_user(body):
@@ -51,6 +52,10 @@ def update_user(username, body):
     errors = validate_update_user(body, params)
     if errors:
         return errors, 400
+
+    if 'password' in params:
+        params['password'] = BCRYPT.generate_password_hash(
+            params['password']).decode('utf-8'),
 
     result, code = db.update(User, username, params)
 

--- a/src/tests/test_user.py
+++ b/src/tests/test_user.py
@@ -86,8 +86,17 @@ class TestUser(unittest.TestCase):
         )
 
         self.assertEqual(status, 200)
+        self.assertEqual(
+            BCRYPT.check_password_hash(result['password'],
+                                       correct_user_update['password']),
+            True
+        )
+
         correct_user_update['username'] = user['username']
-        self.assertEqual(result, correct_user_update)
+        user_without_pswd = correct_user_update.copy()
+        del user_without_pswd['password']
+        del result["password"]
+        self.assertEqual(result, user_without_pswd)
 
         for w_user in wrong_users:
             result, status = controller.update_user(


### PR DESCRIPTION
## Issue 
Fix #18 

## Description
Now when the user updates the password it is also encrypted, without affecting the authentication as before

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## How to validate?
Edit your password and try to authenticate again at no endpoint /api/auth.
Run the tests:
```$ docker-compose run api pytest```