### PR TITLE
Adjust register_date_time value

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     container_name: api-server
     volumes:
       - ./src:/app
+      - "/etc/localtime:/etc/localtime:ro"
     ports:
       - "8083:8083"
     restart: on-failure
@@ -26,6 +27,7 @@ services:
     container_name: database
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
+      - "/etc/localtime:/etc/localtime:ro"
     ports:
      - 5432:5432
 

--- a/src/utils/formatters.py
+++ b/src/utils/formatters.py
@@ -31,6 +31,8 @@ def get_row_dict(row):
     for column in row.__table__.columns:
         attr = getattr(row, column.name)
         if (type(attr) == datetime.datetime):
+            if (column.name == "register_date_time"):
+                attr -= datetime.timedelta(hours=3)
             d[column.name] = str(attr)
         else:
             d[column.name] = attr

--- a/src/utils/formatters.py
+++ b/src/utils/formatters.py
@@ -31,8 +31,6 @@ def get_row_dict(row):
     for column in row.__table__.columns:
         attr = getattr(row, column.name)
         if (type(attr) == datetime.datetime):
-            if (column.name == "register_date_time"):
-                attr -= datetime.timedelta(hours=3)
             d[column.name] = str(attr)
         else:
             d[column.name] = attr


### PR DESCRIPTION
This PR fixes the bug that gives the register_date_time attribute 3 hours ahead of brazil timezone when a occurrence is created.

## Issue #
#8 

## Description
It was changed get_row_dict formatter to reduce 3 hours from the register_date_time attribute.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Known problems (if appropriate):
If you know how to save the register_date_time directly on db with -3 hours. Comment here that i will try to implement.

## How to validate?
Create an occurrence and use the get method to see if the register_date_time is the right time.
